### PR TITLE
Close Issue #8

### DIFF
--- a/src/cli/arguments.rs
+++ b/src/cli/arguments.rs
@@ -7,6 +7,7 @@ use std::env;
 
 pub struct Arguments {
     path: Option<String>,
+    format_output: bool,
     show_time: bool,
 }
 
@@ -17,11 +18,13 @@ impl Arguments {
         let args = env::args().skip(1);
         let mut arguments = Arguments {
             path: None,
+            format_output: false,
             show_time: false,
         };
 
         for arg in args {
             match arg.as_str() {
+                "-f" | "--format-output" => arguments.format_output = true,
                 "-t" | "--show-time" => arguments.show_time = true,
                 _ if arguments.path.is_none() => arguments.path = Some(arg),
                 _ => return Err(Error::message_only(ErrorKind::UnrecognizedArgument(arg))),
@@ -35,6 +38,11 @@ impl Arguments {
     /// This function returns an option because a REPL could be instantiated if no path was defined.
     pub fn get_path(&self) -> Option<&String> {
         self.path.as_ref()
+    }
+
+    /// This function returns if the 'format_output' parameter was passed in.
+    pub fn format_output(&self) -> bool {
+        self.format_output
     }
 
     /// This function retuns if the 'show_time' parameter was passed in.

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -10,7 +10,7 @@ use std::{fs, time::Instant};
 ///
 /// # Arguments
 /// `envy` - A function that deals with the task of the running the Envious code.
-pub fn runner<F: Fn(&str, &str) -> Result<(), String>>(envy: F) -> Result<(), String> {
+pub fn runner<F: Fn(&str, &str, &Arguments) -> Result<(), String>>(envy: F) -> Result<(), String> {
     let args = Arguments::new().map_err(|error| error.prettify(""))?;
     if args.get_path().is_none() {
         generate_error("The REPL Is Not Yet Supported.")
@@ -18,7 +18,7 @@ pub fn runner<F: Fn(&str, &str) -> Result<(), String>>(envy: F) -> Result<(), St
         let contents = fs::read_to_string(path)
             .map_err(|_| "An Error Occurred.\nThe Path Provided Is Not Valid.".to_owned())?;
         let start = Instant::now();
-        if let Err(error) = envy(&contents, path) {
+        if let Err(error) = envy(&contents, path, &args) {
             return Err(error);
         } else if args.show_time() {
             println!("Time Taken: {:#?}", start.elapsed())

--- a/src/main.rs
+++ b/src/main.rs
@@ -21,7 +21,7 @@ mod cli;
 
 use crate::code_generation::CodeGenerator;
 use crate::lexer::Lexer;
-use cli::runner;
+use cli::{arguments::Arguments, runner};
 use parser::Parser;
 
 fn main() {
@@ -32,7 +32,7 @@ fn main() {
 
 /// This runs the lexer, the parser, and the code generator on the contents passed in.
 /// An error is reported if any part of the process returns an error.
-fn run(contents: &str, path: &str) -> Result<(), String> {
+fn run(contents: &str, path: &str, args: &Arguments) -> Result<(), String> {
     let tokens = Lexer::default()
         .lex(contents)
         .map_err(|error| error.prettify(contents))?;
@@ -41,7 +41,7 @@ fn run(contents: &str, path: &str) -> Result<(), String> {
         .parse()
         .map_err(|error| error.prettify(contents))?;
 
-    CodeGenerator::new()
+    CodeGenerator::new(args.format_output())
         .generate_code(&path.replace(".envy", ".dark"), ast)
         .map_err(|error| error.prettify(contents))?;
 

--- a/src/test.dark
+++ b/src/test.dark
@@ -1,2 +1,16 @@
 @main
+    push 123
+    set x pop
+    @__0__
+        push 'Hello, World!'
+        set y pop
+        @__1__
+            push 'Is This Working?'
+        end
+
+        call __1__
+        set y pop
+    end
+
+    call __0__
 end

--- a/src/test.envy
+++ b/src/test.envy
@@ -1,0 +1,7 @@
+let x := 123
+{
+    let y := "Hello, World!"
+    let y := {
+        "Is This Working?"
+    }
+}


### PR DESCRIPTION
Added The Arguments -f and --format-output To The CLI. The compiler now formats the Dark code using 4 spaces of indentation.