### PR TITLE
Infer return type

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,13 @@ In the example above, the condition can be seen as 1 = 1. The action can be thou
 
 The only restriction is that the condition must result in a boolean value.
 
+What if you want to run an expression when the condition is false? Use the else part of the If Expression.
+
+Here is an example:
+```
+if 1 = 2 print('1 Is Equal To 2!') else print('1 Is Not Equal To 2!')
+```
+
 Sometimes, you want to run more than one line of code. In these cases, you can use the **Block Expression**.
 
 A Block Expression is just a bunch of expressions surrounded by a pair of curly braces.

--- a/src/ast/expression_kind.rs
+++ b/src/ast/expression_kind.rs
@@ -19,7 +19,7 @@ pub enum ExpressionKind {
     LetExpression(String, Types, Option<Box<Expression>>),
     FunctionCallExpression(String, Vec<Expression>),
     BlockExpression(Vec<Expression>),
-    IfExpression(Box<Expression>, Box<Expression>),
+    IfExpression(Box<Expression>, Box<Expression>, Option<Box<Expression>>),
     DefineExpression(String, Vec<Parameter>, Box<Expression>, Types)
 }
 

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -255,8 +255,16 @@ impl Parser {
         let (pos, _) = self.tokens.pop_front().unwrap();
         let condition = self.parse_expression(standard_library, type_checker)?;
         let code = Box::new(self.parse_expression(standard_library, type_checker)?);
+        let else_expression = match self.tokens.front() {
+            Some((_, TokenKind::Else)) => {
+                self.tokens.pop_front();
+                Some(Box::new(self.parse_expression(standard_library, type_checker)?))
+            },
+            _ => None
+        };
+
         Ok(Expression::new(
-            ExpressionKind::IfExpression(Box::new(condition), code),
+            ExpressionKind::IfExpression(Box::new(condition), code, else_expression),
             pos,
         ))
     }

--- a/src/test.dark
+++ b/src/test.dark
@@ -1,15 +1,24 @@
 @main
-@perform_math #x #y
-push y
-push x
-push mul
-end
-push 1
-push 1
-call perform_math pop pop
-set x pop
-push 1
-push x
-push add
-printn pop
+    @random #rand
+        push rand
+        jmpf 18
+        @__0__
+            push 'If.'
+            printn pop
+            push 'This is sooo cool'
+        end
+
+        call __0__
+        jmp 28
+        @__1__
+            push 'Else.'
+            printn pop
+            push 'This is cool!'
+        end
+
+        call __1__
+    end
+    push false
+    call random pop
+    print pop
 end

--- a/src/test.dark
+++ b/src/test.dark
@@ -7,4 +7,9 @@ end
 push 1
 push 1
 call perform_math pop pop
+set x pop
+push 1
+push x
+push add
+printn pop
 end

--- a/src/test.envy
+++ b/src/test.envy
@@ -1,4 +1,9 @@
-define perform_math(x: Int, y: Int) :: Int = x * y
+define random(rand: Boolean) = if rand {
+    println("If.")
+    "This is sooo cool"
+} else {
+    println("Else.")
+    "This is cool!"
+}
 
-let x := perform_math(1, 1)
-println(x + true)
+print(random(false))

--- a/src/test.envy
+++ b/src/test.envy
@@ -1,3 +1,4 @@
 define perform_math(x: Int, y: Int) :: Int = x * y
 
-perform_math(1, 1)
+let x := perform_math(1, 1)
+println(x + true)


### PR DESCRIPTION
There are some issues to fix with the type inference and the overall structure. An error occurs when an expression is expected and an if expression is used. If an else section is not added, this should result in an error, but currently, no error is reported and execution continues as normal, producing weird output.